### PR TITLE
Added in white listing

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "com.asuc.asucmobile"
         minSdkVersion 17
         targetSdkVersion 25
-        versionCode 24
-        versionName "6.3.0"
+        versionCode 25
+        versionName "8.0"
         multiDexEnabled true
         vectorDrawables.useSupportLibrary = true
     }
@@ -33,8 +33,9 @@ dependencies {
     compile 'com.android.support:multidex:1.0.1'
 
     compile 'com.google.code.gson:gson:2.8.0'
-    compile 'com.google.android.gms:play-services:10.0.1'
-    compile 'com.google.android.gms:play-services-location:10.0.1'
+    compile 'com.google.android.gms:play-services:11.8.0'
+    compile 'com.google.android.gms:play-services-location:11.8.0'
+    compile 'com.google.firebase:firebase-crash:11.8.0'
 
 
 

--- a/app/src/main/java/com/asuc/asucmobile/main/SplashActivity.java
+++ b/app/src/main/java/com/asuc/asucmobile/main/SplashActivity.java
@@ -6,6 +6,8 @@ import android.os.Bundle;
 import android.util.Log;
 import android.view.Window;
 import android.view.WindowManager;
+import android.provider.Settings;
+import com.google.firebase.crash.FirebaseCrash;
 
 import com.asuc.asucmobile.R;
 import com.asuc.asucmobile.controllers.BMAPI;
@@ -23,6 +25,13 @@ public class SplashActivity extends Activity {
         getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
                 WindowManager.LayoutParams.FLAG_FULLSCREEN); // Removes notification bar
         setContentView(R.layout.activity_splash);
+
+        int adb = Settings.Secure.getInt(this.getContentResolver(), Settings.Global.DEVELOPMENT_SETTINGS_ENABLED , 0);
+        if (adb == 1) {
+            FirebaseCrash.setCrashCollectionEnabled(false);
+        } else {
+            FirebaseCrash.setCrashCollectionEnabled(true);
+        }
 
         // launch network stuff
         BMRetrofitController.create(this, BMAPI.class);


### PR DESCRIPTION
We ran into an issue using firebase crash analytics where it would go off while a developer was testing the app. This little code snippet turns firebase crash analytics off if the user has the developer setting turned on. This also helps us get things ready for going open source.