### PR TITLE
Test structure now mirrors src structure

### DIFF
--- a/app/src/test/java/com/asuc/asucmobile/fragments/MapsFragmentTest.java
+++ b/app/src/test/java/com/asuc/asucmobile/fragments/MapsFragmentTest.java
@@ -1,4 +1,4 @@
-package com.asuc.asucmobile;
+package com.asuc.asucmobile.fragments;
 
 import com.asuc.asucmobile.fragments.MapsFragment;
 


### PR DESCRIPTION
Moved `MapsFragmentTest.java` to `fragments/MapsFragmentTest.java` to reflect the directory structure we have in `src`. @sidthesquid 