### PR TITLE
Fixed library hours text alignment to align right

### DIFF
--- a/app/src/main/java/com/asuc/asucmobile/main/OpenLibraryActivity.java
+++ b/app/src/main/java/com/asuc/asucmobile/main/OpenLibraryActivity.java
@@ -216,7 +216,7 @@ public class OpenLibraryActivity extends BaseActivity {
         // weekly library hours should already be set up when you open the page
         hours.setText(setUpWeeklyHoursLeft());
         hoursParams = hoursLayout.getLayoutParams();
-        hoursLayout.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT, 0.2f));
+        hoursLayout.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT, 0.2f));
         hours_expand.setText(setUpWeeklyHoursRight());
 
     }

--- a/app/src/main/res/layout/activity_open_library.xml
+++ b/app/src/main/res/layout/activity_open_library.xml
@@ -75,7 +75,7 @@
 
                 <TextView
                     android:id="@+id/hours_expand"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginEnd="24dp"
                     android:layout_marginRight="24dp"


### PR DESCRIPTION
The code to right justify the text was already there; I just changed the layout_width for the textview to match_parent instead of wrap_content to fix the right alignment. 

**Before**:
![44148068_338292273385941_1935214003315802112_n](https://user-images.githubusercontent.com/22037555/46985046-458b4c80-d09d-11e8-8bc2-47ce17db1bfb.png)


**After**:
![44215901_1779582452164813_8938926347229593600_n](https://user-images.githubusercontent.com/22037555/46985048-48863d00-d09d-11e8-82ef-868294738f24.png)



