### PR TITLE
Added library sorting by openness then AZ

### DIFF
--- a/app/src/main/java/com/asuc/asucmobile/adapters/LibraryAdapter.java
+++ b/app/src/main/java/com/asuc/asucmobile/adapters/LibraryAdapter.java
@@ -101,7 +101,7 @@ public class LibraryAdapter extends BaseAdapter {
                     imageView.setImageResource(R.drawable.post_favorite);
                 }
 
-                Collections.sort(getLibraries(), CustomComparators.FacilityComparators.getSortByFavoriteLibrary(OpenLibraryActivity.self_reference));
+                Collections.sort(getLibraries(), CustomComparators.FacilityComparators.getSortByFavoriteLibraryThenOpenness(OpenLibraryActivity.self_reference));
                 LibraryFragment.refreshLists();
 
             }

--- a/app/src/main/java/com/asuc/asucmobile/fragments/LibraryFragment.java
+++ b/app/src/main/java/com/asuc/asucmobile/fragments/LibraryFragment.java
@@ -117,7 +117,7 @@ public class LibraryFragment extends Fragment {
                 mAdapter.setList(response.body().getLibraries());
 
                 // sorted by default
-                Collections.sort(mAdapter.getLibraries(), CustomComparators.FacilityComparators.getSortByFavoriteLibrary(getContext()));
+                Collections.sort(mAdapter.getLibraries(), CustomComparators.FacilityComparators.getSortByFavoriteLibraryThenOpenness(getContext()));
 
                 mAdapter.notifyDataSetChanged();
             }

--- a/app/src/main/java/com/asuc/asucmobile/fragments/LibraryFragment.java
+++ b/app/src/main/java/com/asuc/asucmobile/fragments/LibraryFragment.java
@@ -117,8 +117,8 @@ public class LibraryFragment extends Fragment {
                 mAdapter.setList(response.body().getLibraries());
 
                 // sorted by default
-                Collections.sort(mAdapter.getLibraries(), CustomComparators.FacilityComparators.getSortByAZ());
                 Collections.sort(mAdapter.getLibraries(), CustomComparators.FacilityComparators.getSortByFavoriteLibrary(getContext()));
+
                 mAdapter.notifyDataSetChanged();
             }
 

--- a/app/src/main/java/com/asuc/asucmobile/models/Library.java
+++ b/app/src/main/java/com/asuc/asucmobile/models/Library.java
@@ -123,6 +123,8 @@ public class Library implements Comparable<Library>{
 
     @Override
     public int compareTo(@NonNull Library other) {
+        if (this.isOpen() && !other.isOpen()) return -1;
+        if (other.isOpen() && !this.isOpen()) return 1;
         return this.getName().compareTo(other.getName());
     }
 

--- a/app/src/main/java/com/asuc/asucmobile/models/Library.java
+++ b/app/src/main/java/com/asuc/asucmobile/models/Library.java
@@ -123,8 +123,6 @@ public class Library implements Comparable<Library>{
 
     @Override
     public int compareTo(@NonNull Library other) {
-        if (this.isOpen() && !other.isOpen()) return -1;
-        if (other.isOpen() && !this.isOpen()) return 1;
         return this.getName().compareTo(other.getName());
     }
 

--- a/app/src/main/java/com/asuc/asucmobile/utilities/CustomComparators.java
+++ b/app/src/main/java/com/asuc/asucmobile/utilities/CustomComparators.java
@@ -39,6 +39,26 @@ public class CustomComparators {
             };
         }
 
+        public static Comparator<Library> getSortByFavoriteLibraryThenOpenness(final Context context) {
+            return new Comparator<Library>() {
+                @Override
+                public int compare(Library lhs, Library rhs) {
+                    ListOfFavorites listOfFavorites = (ListOfFavorites) SerializableUtilities.loadSerializedObject(context);
+                    if (listOfFavorites == null || lhs == null || rhs == null) {
+                        return 0;
+                    }
+
+                    if (listOfFavorites.contains(lhs.getName()) && !listOfFavorites.contains(rhs.getName())) return -1;
+                    if (listOfFavorites.contains(rhs.getName()) && !listOfFavorites.contains(lhs.getName())) return 1;
+
+                    if (lhs.isOpen() && !rhs.isOpen()) return -1;
+                    if (rhs.isOpen() && !lhs.isOpen()) return 1;
+
+                    return lhs.compareTo(rhs);
+                }
+            };
+        }
+
         public static Comparator<FoodItem> getFoodSortByVegetarian() {
             return foodSortByVegetarian;
         }
@@ -84,6 +104,7 @@ public class CustomComparators {
                 return arg0.compareTo(arg1);
             }
         };
+
         private static Comparator<FoodItem> foodSortByAZ = new Comparator<FoodItem>() {
             public int compare(FoodItem arg0, FoodItem arg1) {
                 return arg0.compareTo(arg1);


### PR DESCRIPTION
I added sorting by openness and then alphabetical order to the default comparaTo method of Library, which also allowed me to get rid of one line of code in LibraryFragment. 

The reason I modified compareTo instead of using more Collections.sort with a comparator is because the comparators use compareTo in the default case (e.g. both libraries are Open, or nothing is favorited), which will use a name comparison and mess up the sorting. I'm open to feedback if there is a better way to do this.