### PR TITLE
changed gradle build order to work on ubuntu

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@
 
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
 
         maven {
             url 'https://maven.fabric.io/public'
@@ -22,8 +22,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
 
         maven {
             url 'https://maven.google.com/'


### PR DESCRIPTION
So Gradle wasn't properly on Ubuntu for me, and after a bit of debugging I came across this [StackOverflow post](https://stackoverflow.com/questions/45692460/failed-to-resolve-com-google-android-gmsplay-services-in-intellij-idea-with-gr), which fixed everything for me and made it so I don't have to start Android Studio with *sudo* anymore. I was hoping we could merge this so I'm able to develop more efficiently on my laptop in the future (I currently work mainly on desktop).