### PR TITLE
Fixed links for bitrise tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ These badges are automatically generated based on our [Bitrise](https://www.bitr
 
 | master        | develop       |
 | ------------- |:-------------:|
-| [![Build Status](https://app.bitrise.io/app/7e8a9de61b96fb28/status.svg?token=iUlmVf7VoO92ggwIkt4Htg&branch=master)](https://app.bitrise.io/app/461008cfa3c83274) | [![Build Status](https://app.bitrise.io/app/7e8a9de61b96fb28/status.svg?token=iUlmVf7VoO92ggwIkt4Htg&branch=develop)](https://app.bitrise.io/app/461008cfa3c83274) |
+| [![Build Status](https://app.bitrise.io/app/7e8a9de61b96fb28/status.svg?token=iUlmVf7VoO92ggwIkt4Htg&branch=master)](https://app.bitrise.io/app/7e8a9de61b96fb28) | [![Build Status](https://app.bitrise.io/app/7e8a9de61b96fb28/status.svg?token=iUlmVf7VoO92ggwIkt4Htg&branch=develop)](https://app.bitrise.io/app/7e8a9de61b96fb28) |
 
 ## What is Berkeley Mobile?
 


### PR DESCRIPTION
Updated the links for the bitrise status tags so they link to our new public Bitrise app instead of the old private one