### PR TITLE
OpenLibraryActivity now supports arbitrarily many open/close times

### DIFF
--- a/app/src/main/java/com/asuc/asucmobile/domain/main/OpenLibraryActivity.java
+++ b/app/src/main/java/com/asuc/asucmobile/domain/main/OpenLibraryActivity.java
@@ -20,6 +20,7 @@ import android.widget.Toast;
 
 import com.asuc.asucmobile.R;
 import com.asuc.asucmobile.domain.models.Library;
+import com.asuc.asucmobile.utilities.HoursStringGenerator;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
 import com.google.android.gms.maps.CameraUpdateFactory;
@@ -34,6 +35,7 @@ import com.google.firebase.analytics.FirebaseAnalytics;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 
@@ -42,8 +44,6 @@ public class OpenLibraryActivity extends BaseActivity {
     public static final String TAG = "OpenLibraryActivity";
 
     private static final LatLng CAMPUS_LOCATION = new LatLng(37.871899, -122.25854);
-    private static final SimpleDateFormat HOURS_FORMAT =
-            new SimpleDateFormat("h:mm a", Locale.ENGLISH);
     private static final int REQUEST_CODE_PLAY_SERVICES = 1;
 
     private MapFragment mapFragment;
@@ -131,7 +131,7 @@ public class OpenLibraryActivity extends BaseActivity {
         TextView address = (TextView) findViewById(R.id.location);
         LinearLayout locationLayout = (LinearLayout) findViewById(R.id.location_layout);
         mapFragment = (MapFragment) getFragmentManager().findFragmentById(R.id.map);
-        address.setText(library.getLocation());
+        address.setText(library.getLocation() != null ? library.getLocation() : library.getName()); // no address, just show name
         locationLayout.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -248,85 +248,10 @@ public class OpenLibraryActivity extends BaseActivity {
         final LinearLayout hoursLayout = (LinearLayout) findViewById(R.id.hours_layout);
 
         // weekly library hours should already be set up when you open the page
-        hours.setText(setUpWeeklyHoursLeft());
+        hours.setText(HoursStringGenerator.setUpWeeklyHoursLeft(library));
         hoursParams = hoursLayout.getLayoutParams();
         hoursLayout.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT, 0.2f));
-        hours_expand.setText(setUpWeeklyHoursRight());
-    }
-
-    /**
-     * This function is called with setUpWeeklyHoursRight() to set up the weekly hours
-     * page, which essentially appears as left and right justified text. The left side
-     * holds days of the week and some description.
-     */
-    private Spanned setUpWeeklyHoursLeft() {
-        ArrayList<Date> openings = library.getWeeklyOpen();
-        Spanned weeklyHoursString = new SpannableString("Today\n");
-        for (int i=0; i < openings.size(); i++) {
-            Spannable hoursString;
-            hoursString = new SpannableString("\n" + library.getDayOfWeek(i));
-            if (i == 0) {
-                hoursString.setSpan(new android.text.style.StyleSpan(android.graphics.Typeface.BOLD), 0, hoursString.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-            }
-
-            weeklyHoursString = (Spanned) TextUtils.concat(weeklyHoursString, hoursString);
-        }
-        return weeklyHoursString;
-    }
-
-    /**
-     * This function is called with setUpWeeklyHoursLeft() to set up the weekly hours
-     * page, which essentially appears as left and right justified text. The right side
-     * holds hours for each day of the week and some description.
-     */
-    private Spanned setUpWeeklyHoursRight() {
-        ArrayList<Date> openings = library.getWeeklyOpen();
-        ArrayList<Date> closings = library.getWeeklyClose();
-        ArrayList<Boolean> byAppointments = library.getWeeklyAppointments();
-        Spannable hoursString;
-        if (library.isByAppointment()) {
-//            hoursString = new SpannableString("BY APPOINTMENT  ▲\n");
-            hoursString = new SpannableString("BY APPOINTMENT\n");
-            hoursString.setSpan(new ForegroundColorSpan(ContextCompat.getColor(getApplicationContext(),R.color.pavan_light )), 0, hoursString.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
-        } else if (library.getOpening() != null && library.getClosing() != null) {
-            String isOpen;
-            int color;
-            if (library.isOpen()) {
-//                isOpen = "OPEN  ▲";
-                isOpen = "OPEN";
-                color = ContextCompat.getColor(getApplicationContext(),R.color.green);
-            } else {
-//                isOpen = "CLOSED  ▲";
-                isOpen = "CLOSED";
-                color = ContextCompat.getColor(getApplicationContext(),R.color.red);
-            }
-
-            hoursString = new SpannableString(isOpen + "\n");
-            hoursString.setSpan(new ForegroundColorSpan(color), 0, hoursString.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
-        } else {
-//            hoursString = new SpannableString("CLOSED ALL DAY  ▲\n");
-            hoursString = new SpannableString("CLOSED ALL DAY\n");
-            hoursString.setSpan(new ForegroundColorSpan(ContextCompat.getColor(getApplicationContext(),R.color.maroon) ), 0, hoursString.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
-        }
-        Spanned weeklyHoursString = hoursString;
-        for (int i=0; i < openings.size(); i++) {
-            if (byAppointments.get(i)) {
-                hoursString = new SpannableString("\n  BY APPOINTMENT");
-                hoursString.setSpan(new ForegroundColorSpan(ContextCompat.getColor(getApplicationContext(),R.color.pavan_light) ), 0, hoursString.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
-            } else if (openings.get(i) != null && closings.get(i) != null) {
-                String opening = HOURS_FORMAT.format(openings.get(i));
-                String closing = HOURS_FORMAT.format(closings.get(i));
-                hoursString = new SpannableString("\n" + opening + " - " + closing);
-            } else {
-                hoursString = new SpannableString("\n  CLOSED ALL DAY");
-                hoursString.setSpan(new ForegroundColorSpan(ContextCompat.getColor(getApplicationContext(),R.color.maroon) ), 0, hoursString.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
-            }
-            if (i == 0) {
-                hoursString.setSpan(new android.text.style.StyleSpan(android.graphics.Typeface.BOLD), 0, hoursString.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-            }
-            weeklyHoursString = (Spanned) TextUtils.concat(weeklyHoursString, hoursString);
-        }
-        return weeklyHoursString;
+        hours_expand.setText(HoursStringGenerator.setUpWeeklyHoursRight(library, getApplicationContext()));
     }
 
     /**

--- a/app/src/main/java/com/asuc/asucmobile/infrastructure/transformers/LibraryTransformer.java
+++ b/app/src/main/java/com/asuc/asucmobile/infrastructure/transformers/LibraryTransformer.java
@@ -5,10 +5,13 @@ import android.util.Log;
 import com.asuc.asucmobile.infrastructure.models.Library;
 import com.asuc.asucmobile.infrastructure.models.MultiOpenClose;
 import com.asuc.asucmobile.infrastructure.models.OpenClose;
+import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.QuerySnapshot;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 

--- a/app/src/main/java/com/asuc/asucmobile/utilities/HoursStringGenerator.java
+++ b/app/src/main/java/com/asuc/asucmobile/utilities/HoursStringGenerator.java
@@ -1,0 +1,109 @@
+package com.asuc.asucmobile.utilities;
+
+import android.content.Context;
+import android.support.v4.content.ContextCompat;
+import android.text.Spannable;
+import android.text.SpannableString;
+import android.text.Spanned;
+import android.text.TextUtils;
+import android.text.style.ForegroundColorSpan;
+import android.util.Log;
+
+import com.asuc.asucmobile.R;
+import com.asuc.asucmobile.domain.models.Library;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+
+public class HoursStringGenerator {
+
+    private static final SimpleDateFormat HOURS_FORMAT =
+            new SimpleDateFormat("h:mm a", Locale.ENGLISH);
+
+    public static Spanned setUpWeeklyHoursLeft(Library library) {
+        return setUpWeeklyHoursLeft(library.getWeeklyOpen());
+    }
+
+    public static Spanned setUpWeeklyHoursRight(Library library, Context context) {
+        return setUpWeeklyHoursRight(library.getWeeklyOpen(), library.getWeeklyClose(), library.getWeeklyAppointments(), library.isOpen(), library.isByAppointment(), context);
+    }
+
+    /**
+     * This function is called with setUpWeeklyHoursRight() to set up the weekly hours
+     * page, which essentially appears as left and right justified text. The left side
+     * holds days of the week and some description.
+     */
+    private static Spanned setUpWeeklyHoursLeft(ArrayList<Date> openings) {
+        Spanned weeklyHoursString = new SpannableString("Today\n");
+        Calendar c = Calendar.getInstance();
+        c.setTime(new Date());
+        int today = c.get(Calendar.DAY_OF_WEEK);
+        for (int i = 0; i < openings.size(); i++) {
+            Spannable hoursString;
+            c.setTime(openings.get(i));
+            String dayName = new SimpleDateFormat("EEEE", Locale.ENGLISH).format(openings.get(i));
+            hoursString = new SpannableString("\n" + dayName);
+            if (today == c.get(Calendar.DAY_OF_WEEK)) {
+                hoursString.setSpan(new android.text.style.StyleSpan(android.graphics.Typeface.BOLD), 0, hoursString.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+            }
+
+            weeklyHoursString = (Spanned) TextUtils.concat(weeklyHoursString, hoursString);
+        }
+        return weeklyHoursString;
+    }
+
+    /**
+     * This function is called with setUpWeeklyHoursLeft() to set up the weekly hours
+     * page, which essentially appears as left and right justified text. The right side
+     * holds hours for each day of the week and some description.
+     */
+    private static Spanned setUpWeeklyHoursRight(ArrayList<Date> openings, ArrayList<Date> closings, ArrayList<Boolean> byAppointments, boolean open, boolean isByAppointment, Context context) {
+        Spannable hoursString;
+        Calendar c = Calendar.getInstance();
+        c.setTime(new Date());
+        int today = c.get(Calendar.DAY_OF_WEEK);
+        if (isByAppointment) {
+            hoursString = new SpannableString("BY APPOINTMENT\n");
+            hoursString.setSpan(new ForegroundColorSpan(ContextCompat.getColor(context, R.color.pavan_light )), 0, hoursString.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
+        } else if (openings != null && closings != null) {
+            String isOpen;
+            int color;
+            if (open) {
+                isOpen = "OPEN";
+                color = ContextCompat.getColor(context,R.color.green);
+            } else {
+                isOpen = "CLOSED";
+                color = ContextCompat.getColor(context,R.color.red);
+            }
+
+            hoursString = new SpannableString(isOpen + "\n");
+            hoursString.setSpan(new ForegroundColorSpan(color), 0, hoursString.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
+        } else {
+            hoursString = new SpannableString("CLOSED ALL DAY\n");
+            hoursString.setSpan(new ForegroundColorSpan(ContextCompat.getColor(context,R.color.maroon) ), 0, hoursString.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
+        }
+        Spanned weeklyHoursString = hoursString;
+        for (int i=0; i < openings.size(); i++) {
+            if (byAppointments.get(i)) {
+                hoursString = new SpannableString("\n  BY APPOINTMENT");
+                hoursString.setSpan(new ForegroundColorSpan(ContextCompat.getColor(context,R.color.pavan_light) ), 0, hoursString.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
+            } else if (openings.get(i) != null && closings.get(i) != null) {
+                String opening = HOURS_FORMAT.format(openings.get(i));
+                String closing = HOURS_FORMAT.format(closings.get(i));
+                hoursString = new SpannableString("\n" + opening + " - " + closing);
+            } else {
+                hoursString = new SpannableString("\n  CLOSED ALL DAY");
+                hoursString.setSpan(new ForegroundColorSpan(ContextCompat.getColor(context,R.color.maroon) ), 0, hoursString.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
+            }
+            c.setTime(openings.get(i));
+            if (today == c.get(Calendar.DAY_OF_WEEK)) {
+                hoursString.setSpan(new android.text.style.StyleSpan(android.graphics.Typeface.BOLD), 0, hoursString.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+            }
+            weeklyHoursString = (Spanned) TextUtils.concat(weeklyHoursString, hoursString);
+        }
+        return weeklyHoursString;
+    }
+}


### PR DESCRIPTION
Fixes wrt new schema for firestore:
* Originally assumed open/close times provided as `current_day + 7 days`
* Now can be arbitrarily many open/close times, and up to client to display

Also separated out Spanned string generation for UI to `HoursStringGenerator.java`